### PR TITLE
Fix: Make Goal a normally Monitored Location

### DIFF
--- a/source/DSAP/App.axaml.cs
+++ b/source/DSAP/App.axaml.cs
@@ -238,9 +238,6 @@ public partial class App : Application
         //var fogWallLocations = Helpers.GetFogWallFlagLocations();
         var miscLocations = Helpers.GetMiscFlagLocations();
 
-        var goalLocation = (Location)bossLocations.First(x => x.Name.Contains("Lord of Cinder"));
-        Memory.MonitorAddressBitForAction(goalLocation.Address, goalLocation.AddressBit, () => Client.SendGoalCompletion());
-
         var fullLocationsList = bossLocations.Union(itemLocations).Union(bonfireLocations).Union(doorLocations).Union(miscLocations).ToList();
         Client.MonitorLocations(fullLocationsList);
 
@@ -407,6 +404,11 @@ public partial class App : Application
     private void Client_LocationCompleted(object? sender, Archipelago.Core.Models.LocationCompletedEventArgs e)
     {
         var locid = e.CompletedLocation.Id;
+        if (e.CompletedLocation.Name.Contains("Lord of Cinder"))
+        {
+            Client.SendGoalCompletion();
+        }
+
         /* If the check was in non-itemlot locations, give the player items for it */
         if (ConditionRewardMap.ContainsKey(locid))
         {


### PR DESCRIPTION
Adds "IsInGame()" check-safety. 

Tested by:
Writing the Gwyn flag after connecting while in menu - it did not send goal (good!) <- previously a problem case, now fixed
Writing the Gwyn flag after connecting while in game - it did send goal (good)
Also went and killed Gwyn and it sent it (good)