### PR TITLE
Fix All Bosses goal, Apworld ver => v0.1.0.3

### DIFF
--- a/apworld/dsr/Options.py
+++ b/apworld/dsr/Options.py
@@ -193,10 +193,10 @@ class GoalConditionOption(Choice):
     """Set the goal condition
     
     - **Gwyn:** Default option -Beat Gwyn, Lord of Cinder
-    - **Bosses:** Beat all bosses"""
+    - **Bosses:** Defeat all bosses"""
     display_name = "Goal Condition"
     option_gwyn = 0
-    option_bosses = 1
+    option_all_bosses = 1
     default = 0
     
 # Group relevant options

--- a/apworld/dsr/__init__.py
+++ b/apworld/dsr/__init__.py
@@ -10,7 +10,7 @@ from worlds.generic.Rules import set_rule, add_rule, add_item_rule
 from .Items import DSRItem, DSRItemCategory, item_dictionary, key_item_names, item_descriptions, BuildRequiredItemPool, BuildGuaranteedItemPool, UpgradeEquipment
 from .Locations import DSRLocation, DSRLocationCategory, location_tables, location_dictionary, location_skip_categories, location_locked_categories
 from .Groups import location_name_groups, item_name_groups
-from .Options import DSROption, option_groups, LogicToAccessCatacombs
+from .Options import DSROption, option_groups, LogicToAccessCatacombs, GoalConditionOption
 
 from settings import Group, FilePath
 
@@ -637,18 +637,19 @@ class DSRWorld(World):
         for region in self.multiworld.get_regions(self.player):
             for location in region.locations:
                     set_rule(location, lambda state: True)       
-        if self.options.goal_condition.value == 0:
-            self.multiworld.completion_condition[self.player] = lambda state: state.has("Gwyn, Lord of Cinder Defeated", self.player)
-        elif self.options.goal_condition.value == 1:
-            boss_defeated_items = [
-                item.name
-                for item in item_dictionary.values()
-                if item.category == DSRItemCategory.EVENT and "Defeated" in item.name
-            ]
+        match self.options.goal_condition:
+            case GoalConditionOption.option_gwyn:
+                self.multiworld.completion_condition[self.player] = lambda state: state.has("Gwyn, Lord of Cinder Defeated", self.player)
+            case GoalConditionOption.option_all_bosses:
+                boss_defeated_items = [
+                    item.name
+                    for item in item_dictionary.values()
+                    if item.category == DSRItemCategory.EVENT and "Defeated" in item.name
+                ]
             
-            self.multiworld.completion_condition[self.player] = lambda state, items=boss_defeated_items: all(
-                state.has(item, self.player) for item in items
-            )
+                self.multiworld.completion_condition[self.player] = lambda state, items=boss_defeated_items: all(
+                    state.has(item, self.player) for item in items
+                )
             
 
         set_rule(self.multiworld.get_entrance("Undead Asylum Cell -> Undead Asylum Cell Door", self.player), lambda state: state.has("Dungeon Cell Key", self.player))   
@@ -901,11 +902,12 @@ class DSRWorld(World):
 
         slot_data = {
             "options": {
+                "goal_condition": self.options.goal_condition.current_key, # text of the option
                 "can_warp_without_lordvessel": self.options.can_warp_without_lordvessel.value,
                 "guaranteed_items": self.options.guaranteed_items.value,
                 "fogwall_sanity": self.options.fogwall_sanity.value,
                 "boss_fogwall_sanity": self.options.boss_fogwall_sanity.value,
-                "logic_to_access_catacombs": self.options.logic_to_access_catacombs.current_key,
+                "logic_to_access_catacombs": self.options.logic_to_access_catacombs.current_key, # text of the option
                 "randomize_starting_loadouts": self.options.randomize_starting_loadouts.value,
                 "randomize_starting_gifts": self.options.randomize_starting_gifts.value,
                 "require_one_handed_starting_weapons": self.options.require_one_handed_starting_weapons.value,
@@ -930,7 +932,7 @@ class DSRWorld(World):
             "itemsId": items_id,
             "itemsUpgrades": items_upgrades,
             "itemsAddress": items_address,
-            "apworld_api_version" : "0.1.0.0" # Manually set our apworld api level, for detecting compatibility with client
+            "apworld_api_version" : "0.1.0.3" # Manually set our apworld api level, for detecting compatibility with client
         }
 
         self.items_id = items_id

--- a/source/DSAP/App.axaml.cs
+++ b/source/DSAP/App.axaml.cs
@@ -477,28 +477,25 @@ public partial class App : Application
     {
         Log.Logger.Warning("Beginning /goalcheck processing");
         bool sendingGoal = false;
-        int.TryParse(Client.Options["goal_condition"]?.ToString() ?? "0", out var goal);
-
 
         // Begin by stating what the goal is.
-        // Later, if there are other options, display the appropriate goal, and update the checks performed.
-        if (goal == (int)DSGoal.Gwyn)
+        if (DSOptions.Goal == DSGoal.Gwyn)
         {
             Log.Logger.Warning("Your goal is to defeat Gwyn, Lord of Cinder.");
         }
-        else if (goal == (int)DSGoal.AllBosses)
+        else if (DSOptions.Goal == DSGoal.AllBosses)
         {
             Log.Logger.Warning("Your goal is to defeat All Bosses.");
         }
-        PrintDiagnosticInfo();
+        else
+        {
+            Log.Logger.Warning("Unknown goal condition detected.");
+        }
 
-        // check if goal is completed
+        // check if that goal is completed
         if (MiscHelper.IsInGame())
         {
-            ulong baseb = AddressHelper.GetBaseBAddress();
-            Log.Logger.Warning($"$Baseb={baseb:X}");
-
-            if (goal == (int)DSGoal.Gwyn)
+            if (DSOptions.Goal == DSGoal.Gwyn)
             {
                 var locs = Client.CurrentSession.Locations.AllLocationsChecked.Where(x => x == 11110499 || x == 11110500);
                 foreach (var loc in locs)
@@ -506,39 +503,21 @@ public partial class App : Application
                     Log.Logger.Warning($"Lord of Cinder location ({loc}) found as completed. Completing goal.");
                     sendingGoal = true;
                 }
-            }
-            else if (goal == (int)DSGoal.AllBosses)
-            {
-                var bosses = Helpers.LocationHelper.GetBossFlagLocations();
-                var locs = Client.CurrentSession.Locations.AllLocations.Where(x => bosses.Any(y => y.Id == x));
-                if (Client.CurrentSession.Locations.AllLocationsChecked.Count(x => locs.Any(y => y == x)) == locs.Count())
+                ulong baseb = AddressHelper.GetBaseBAddress();
+                if (baseb > 0)
                 {
-                    sendingGoal = true;
+                    int ngplus = Memory.ReadByte(baseb + 0x78);
+                    if (ngplus > 0)
+                    {
+                        Log.Logger.Warning($"ng+{ngplus} detected. Completing goal.");
+                        sendingGoal = true;
+                    }
                 }
-            }
-            else
-            {
-                Log.Logger.Warning("Goal condition not detected. If this is unexpected, please report this to the developers.");
-            }
-
-
-            if (baseb > 0)
-            {
-
-                int ngplus = Memory.ReadByte(baseb + 0x78);
-                if (ngplus > 0)
+                else
                 {
-                    Log.Logger.Warning($"ng+{ngplus} detected. Completing goal.");
-                    sendingGoal = true;
+                    Log.Logger.Warning("baseb could not be resolved");
                 }
-            }
-            else
-            {
-                Log.Logger.Warning("baseb could not be resolved");
-            }
 
-            if (goal == (int)DSGoal.Gwyn)
-            {
                 var gwynloc = (Location)LocationHelper.GetBossFlagLocations().Where(x => x.Name == "Gwyn, Lord of Cinder").First();
                 if (gwynloc != null)
                 {
@@ -564,6 +543,43 @@ public partial class App : Application
                     Log.Logger.Warning("No Gwyn location found");
                 }
             }
+            else if (DSOptions.Goal == DSGoal.AllBosses)
+            {
+                var bossLocs = LocationHelper.GetBossFlagLocations();
+                bossLocs.Sort((x, y) => x.Name.CompareTo(y.Name));
+
+                int total_bosses = bossLocs.Count;
+                int completed_bosses = 0;
+                foreach (var boss in bossLocs)
+                {
+                    if (boss.Check())
+                    {
+                        completed_bosses++;
+                    }
+                }
+                if (completed_bosses == total_bosses)
+                {
+                    Log.Logger.Information($"Sending Goal for All Bosses");
+                    sendingGoal = true;
+                }
+                else
+                {
+                    Client.AddOverlayMessage($"You have defeated {completed_bosses}/{total_bosses} bosses.");
+                    Log.Logger.Information($"You have defeated {completed_bosses}/{total_bosses} bosses.");
+                    foreach (var boss in bossLocs)
+                    {
+                        if (boss.Check())
+                            Log.Logger.Information($"[x] {boss.Name}");
+                        else
+                            Log.Logger.Information($"[_] {boss.Name}");
+                    }
+                }
+            }
+            else
+            {
+                Log.Logger.Information("Unknown goal condition detected.");
+            }
+
             if (MiscHelper.IsInGame())
             {
                 if (sendingGoal)
@@ -574,10 +590,6 @@ public partial class App : Application
                 {
                     Log.Logger.Warning("Goal condition not detected. If this is unexpected, please report this to the developers.");
                 }
-
-                Log.Logger.Error("Please help us! Included in these messages are useful diagnostics.");
-                Log.Logger.Error("Please post a screenshot of this log in the AP discord's 'dark-souls' channel.");
-                Client.AddOverlayMessage($"Action required - see log for details.");
             }
             else
             {
@@ -1136,8 +1148,7 @@ public partial class App : Application
     private static void Client_LocationCompleted(object? sender, Archipelago.Core.Models.LocationCompletedEventArgs e)
     {
         var locid = e.CompletedLocation.Id;
-        int.TryParse(Client.Options["goal_condition"]?.ToString() ?? "0", out var goal);
-        if (goal == (int)DSGoal.Gwyn)
+        if (DSOptions.Goal == DSGoal.Gwyn)
         {
             if (e.CompletedLocation.Name.Contains("Lord of Cinder"))
             {
@@ -1150,26 +1161,38 @@ public partial class App : Application
                 SendGoal();
             }
         }
-        else if (goal == (int)DSGoal.AllBosses)
+        else if (DSOptions.Goal == DSGoal.AllBosses)
         {
             var hasGoaledBosses = true;
-            var bossLocs = Helpers.LocationHelper.GetBossFlagLocations();
-            if(bossLocs.Any(x => x.Name == e.CompletedLocation.Name))
+            var bossLocs = LocationHelper.GetBossFlagLocations();
+            bossLocs.Sort((x, y) => x.Name.CompareTo(y.Name));
+
+            if (bossLocs.Any(x => x.Name == e.CompletedLocation.Name)) // only bother doing all the checks if current location is in the list
             {
+                int total_bosses = bossLocs.Count;
+                int completed_bosses = 0;
                 foreach (var boss in bossLocs) 
                 {
-                    if (!boss.Check())
+                    if (boss.Check())
                     {
-                        hasGoaledBosses = false;
+                        completed_bosses++;
                     }
                 }
-                if(hasGoaledBosses)
+                Log.Logger.Information($"Boss defeated: {e.CompletedLocation.Name}");
+                Client.AddOverlayMessage($"Boss defeated: {e.CompletedLocation.Name}");
+                if (completed_bosses == total_bosses)
                 {
                     Log.Logger.Information($"Sending Goal for All Bosses");
                     SendGoal();
                 }
+                else
+                {
+                    Client.AddOverlayMessage($"You have defeated {completed_bosses}/{total_bosses} bosses.");
+                    Log.Logger.Information($"You have defeated {completed_bosses}/{total_bosses} bosses.");
+                }
             }
         }
+
         // if it's in our scouted locs & not in our own game,
         if (scoutedLocationInfo.TryGetValue(e.CompletedLocation.Id, out var value) && value.Player.Slot != Client.CurrentSession.ConnectionInfo.Slot)
         {

--- a/source/DSAP/Models/DarkSoulsOptions.cs
+++ b/source/DSAP/Models/DarkSoulsOptions.cs
@@ -14,6 +14,8 @@ namespace DSAP.Models
         public uint apiver_minor;
         public uint apiver_revision;
         public uint apiver_build;
+        // Game
+        public Enums.DSGoal Goal {  get; set; }
         // QoL
         public bool CanWarpWithoutLordvessel {  get; set; }
         // equipment
@@ -97,6 +99,26 @@ namespace DSAP.Models
                 apiver_build    = 1;
                 outofdate = true;
             }
+
+            if (App.Client.Options.ContainsKey("goal_condition"))
+            {
+                string GoalString = ((JsonElement)App.Client.Options["goal_condition"]).GetString();
+                switch (GoalString)
+                {
+                    case "gwyn":
+                        Goal = Enums.DSGoal.Gwyn;
+                        break;
+                    case "all_bosses":
+                        Goal = Enums.DSGoal.AllBosses;
+                        break;
+                    default:
+                        Goal = Enums.DSGoal.Gwyn;
+                        break;
+                }
+            }
+            else
+                Goal = Enums.DSGoal.Gwyn;
+
             // warp option
             CanWarpWithoutLordvessel = GetBool("can_warp_without_lordvessel");
 


### PR DESCRIPTION
Fix condition checks
Save goal condition in slotdata
Add goal condition to options class in client
Add progress count when bosses are defeated, and printout list of defeated/undefeated bosses on /goalcheck.
Update apworld version

Tested with existing save files on a newly generated apworld to trigger gwyn and all_bosses goal completion once each. Spoiler log for generated apworld looked ok too